### PR TITLE
Update onlinemapsources with Historic USGS Topo

### DIFF
--- a/docs/onlinemapsources.xml
+++ b/docs/onlinemapsources.xml
@@ -1089,6 +1089,26 @@
 		<qop></qop>
 	</onlinemapsource>
 	
+	<onlinemapsource uid="198">
+        <name>USGS Historic Topo (US)</name>
+        <url><![CDATA[https://server.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{$z}/{$y}/{$x}]]></url>
+        <website><![CDATA[<a href="https://www.arcgis.com/home/item.html?id=99cd5fbd98934028802b4f797c4b1732">USA Topo Maps
+</a>]]></website>
+        <minzoom>0</minzoom>
+        <maxzoom>15</maxzoom>
+        <projection>MERCATORESFERICA</projection>
+        <servers></servers>
+        <httpparam name=""></httpparam>
+        <cacheable>1</cacheable>
+        <downloadable>1</downloadable>
+        <maxtilesday>0</maxtilesday>
+        <maxthreads>0</maxthreads>
+        <xop></xop>
+        <yop></yop>
+        <zop></zop>
+        <qop></qop>
+    </onlinemapsource>
+
     <onlinemapsource uid="197">
         <name>USGS Topo (US)</name>
         <url><![CDATA[http://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/{$z}/{$y}/{$x}]]></url>


### PR DESCRIPTION
Add USA Topo Maps, which on a small scale are composed of historic USGS topographic maps.
These maps are useful when hiking in the US, as they are hand drawn and contain features such as trails, old settlements, old roads, and man-made objects. The current USGS Topo maps are automatically generated and contain a lot less detail.

在美國這份就像是台灣的經建版